### PR TITLE
Implement poison applier effect link and v13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # PF2e-Foundry-VTT-Poison-Applier
-Let poisons apply to a weapon
+
+Dieses Modul erlaubt es, Gifte aus dem Inventar direkt auf Waffen anzuwenden.
+Kompatibel mit Foundry VTT v13.
+
+## Nutzung
+
+Nach dem Aktivieren des Moduls wird bei Spielstart automatisch ein Makro
+"Poison Applicator" erstellt. Wird es ausgeführt, öffnet sich ein Dialog, in dem
+eine Waffe und ein Gift aus dem Inventar des gewählten Tokens ausgewählt werden
+können. Nach der Auswahl erhält das Token einen Effekt, der einen Link zum
+entsprechenden Gift enthält. Die Menge des verwendeten Gifts wird dabei um eins
+reduziert.

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "type": "module",
   "compatibility": {
     "minimum": "11",
-    "verified": "12"
+    "verified": "13"
   },
   "authors": [
     {

--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -20,11 +20,14 @@ export async function applyPoisonEffect(actor, weapon, poison) {
         type: "effect",
         img: poison.img,
         system: {
-            description: { value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet.</p>` },
+            description: {
+                value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet.</p>` +
+                       `<p>Nutze @UUID[Actor.${actor.id}.Item.${poison.id}]{${poison.name}} für alle Würfe.</p>`
+            },
             duration: { value: 10, unit: "rounds" },
             tokenIcon: { show: true },
             rules: [],
-            slug: `poisoned-weapon-${actor.id}`
+            slug: `poisoned-weapon-${actor.id}-${weapon.id}`
         }
     };
 
@@ -35,15 +38,11 @@ export async function applyPoisonEffect(actor, weapon, poison) {
         console.error("❌ Fehler beim Hinzufügen des Effekts am Token:", error);
     }
 
-    // 🎯 Das Gift aus dem Inventar entfernen oder reduzieren
+    // 🎯 Die Menge des Gifts im Inventar verringern
     let newQuantity = (poison.system.quantity ?? 1) - 1;
-    if (newQuantity <= 0) {
-        await poison.delete();
-        console.log(`🗑️ ${poison.name} wurde aus dem Inventar entfernt.`);
-    } else {
-        await poison.update({ "system.quantity": newQuantity });
-        console.log(`🔢 ${poison.name} wurde reduziert auf ${newQuantity}.`);
-    }
+    if (newQuantity < 0) newQuantity = 0;
+    await poison.update({ "system.quantity": newQuantity });
+    console.log(`🔢 ${poison.name} wurde reduziert auf ${newQuantity}.`);
 
     // 💬 Nachricht im Chat posten
     ChatMessage.create({


### PR DESCRIPTION
## Summary
- adjust module compatibility to Foundry v13
- include instructions in README
- add a persistent link to the poison item in the applied effect
- keep the poison item in inventory but reduce its quantity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a1f868ec48327877605160929e889