### PR TITLE
Link poison with default name

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -19,10 +19,15 @@ export async function applyPoisonEffect(actor, weapon, poison) {
         name: `Vergiftete Waffe (${poison.name})`,
         type: "effect",
         img: poison.img,
+        flags: {
+            core: {
+                sourceId: poison.uuid
+            }
+        },
         system: {
             description: {
                 value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet.</p>` +
-                       `<p>Nutze @UUID[Actor.${actor.id}.Item.${poison.id}]{${poison.name}} für alle Würfe.</p>`
+                       `<p>Nutze @UUID[${poison.uuid}] für alle Würfe.</p>`
             },
             duration: { value: 10, unit: "rounds" },
             tokenIcon: { show: true },


### PR DESCRIPTION
## Summary
- show the poison item using `@UUID[...]` without a custom name so Foundry displays the default item name

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688a630072ec8327949b125053d562ba