### PR TITLE
Align dropdown CSS selectors

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -1,4 +1,4 @@
-#weapon-select, #poison-select {
+#weapon, #poison {
   width: 100%;
   padding: 5px;
 }


### PR DESCRIPTION
## Summary
- use `#weapon` and `#poison` selectors in CSS so the dialog dropdowns get 100% width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b11e1d5c083278aca37a3ab95e797