### PR TITLE
Use template for poison dialog

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -53,21 +53,8 @@ async function showPoisonDialog(actor) {
         return;
     }
 
-    let weaponOptions = weapons.map(w => `<option value="${w.id}">${w.name}</option>`).join("");
-    let poisonOptions = poisons.map(p => `<option value="${p.id}">${p.name}</option>`).join("");
-
-    let content = `
-        <form>
-            <div class="form-group">
-                <label>Waffe:</label>
-                <select id="weapon">${weaponOptions}</select>
-            </div>
-            <div class="form-group">
-                <label>Gift:</label>
-                <select id="poison">${poisonOptions}</select>
-            </div>
-        </form>
-    `;
+    const templatePath = "modules/poison-applier/templates/apply-poison.html";
+    const content = await renderTemplate(templatePath, { weapons, poisons });
 
     new Dialog({
         title: "Gift auf Waffe auftragen",

--- a/templates/apply-poison.html
+++ b/templates/apply-poison.html
@@ -1,1 +1,18 @@
-
+<form>
+    <div class="form-group">
+        <label>Waffe:</label>
+        <select id="weapon">
+            {{#each weapons}}
+            <option value="{{this.id}}">{{this.name}}</option>
+            {{/each}}
+        </select>
+    </div>
+    <div class="form-group">
+        <label>Gift:</label>
+        <select id="poison">
+            {{#each poisons}}
+            <option value="{{this.id}}">{{this.name}}</option>
+            {{/each}}
+        </select>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- build a handlebars template for the poison application dialog
- load the template in `showPoisonDialog` instead of constructing HTML strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b11e3abbc832797cbccb1107be9ec