### PR TITLE
Improve poison effect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # PF2e-Foundry-VTT-Poison-Applier
 
-Dieses Modul erlaubt es, Gifte aus dem Inventar direkt auf Waffen anzuwenden.
-Kompatibel mit Foundry VTT v13.
+Dieses Modul erleichtert es, den Einsatz von Giften in Foundry VTT zu verfolgen. Nach dem Auftragen wird deutlich angezeigt, welche Waffe mit welchem Gift behandelt wurde.
 
 ## Nutzung
 
-Nach dem Aktivieren des Moduls wird bei Spielstart automatisch ein Makro
-"Poison Applicator" erstellt. Wird es ausgeführt, öffnet sich ein Dialog, in dem
-eine Waffe und ein Gift aus dem Inventar des gewählten Tokens ausgewählt werden
-können. Nach der Auswahl erhält das Token einen Effekt, der einen Link zum
-entsprechenden Gift enthält. Die Menge des verwendeten Gifts wird dabei um eins
-reduziert.
+Nach dem Aktivieren des Moduls wird beim Spielstart automatisch ein Makro **"Poison Applicator"** erstellt. Führe dieses Makro aus, um einen Dialog zu öffnen. Dort wählst du eine Waffe und ein passendes Gift aus dem Inventar des gewählten Tokens.
+
+Nach der Auswahl wird auf dem Token ein Effekt angelegt. Dieser Effekt verlinkt auf das im Spiel hinterlegte Gift und zeigt an, auf welche Waffe es aufgetragen wurde. Aus dem Effekt heraus lassen sich alle Würfe des Giftes (z.B. Schadens- oder Rettungswürfe) verwenden. Gleichzeitig wird die Menge des verwendeten Giftes im Inventar um eins reduziert.
+
+Kompatibel mit Foundry VTT v13.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "poison-applier",
   "title": "PF2e Poison-Applier",
   "description": "Ermöglicht das Auftragen von Giften auf Waffen mit visuellen Effekten.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "type": "module",
   "compatibility": {
     "minimum": "11",

--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -1,117 +1,46 @@
 export async function applyPoisonEffect(actor, weapon, poison) {
-    console.log(`✅ ${actor.name} trägt ${poison.name} auf ${weapon.name} auf.`);
+  console.log(`✅ ${actor.name} trägt ${poison.name} auf ${weapon.name} auf.`);
 
-    // 🎯 Effekt für die Waffe setzen (im Angriff)
-    let attackEffects = weapon.system.attackEffects?.value || [];
-    if (!attackEffects.includes("poison")) {
-        attackEffects.push("poison");
+  // Add poison trait to the weapon's attack effects
+  const attackEffects = Array.from(weapon.system.attackEffects?.value || []);
+  if (!attackEffects.includes("poison")) {
+    attackEffects.push("poison");
+    await weapon.update({"system.attackEffects.value": attackEffects});
+  }
+
+  const effectData = {
+    name: `Vergiftete Waffe (${poison.name})`,
+    type: "effect",
+    img: poison.img,
+    flags: {
+      core: { sourceId: poison.uuid }
+    },
+    system: {
+      slug: `poisoned-weapon-${actor.id}-${weapon.id}`,
+      tokenIcon: { show: true },
+      duration: { value: 10, unit: "rounds" },
+      rules: [],
+      description: {
+        value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet. @UUID[${poison.uuid}]{${poison.name}}</p>` +
+               (poison.system?.description?.value || ""),
+        gm: poison.system?.description?.gm || ""
+      }
     }
+  };
 
-    try {
-        await weapon.update({ "system.attackEffects.value": attackEffects });
-        console.log("🛠️ Waffe aktualisiert mit Gift-Effekt:", attackEffects);
-    } catch (error) {
-        console.error("❌ Fehler beim Anwenden des Effekts auf die Waffe:", error);
-    }
+  try {
+    await actor.createEmbeddedDocuments("Item", [effectData]);
+  } catch (error) {
+    console.error("❌ Fehler beim Hinzufügen des Effekts am Token:", error);
+  }
 
-    // 🎯 Effekt als echtes PF2e-Item hinzufügen (sichtbar in der Effekt-Liste)
-//wnwig2-codex/makro-fur-poison-applicator-hinzufugen
-    const poisonDesc = poison.system?.description?.value || "";
-    const poisonDescGm = poison.system?.description?.gm || "";
-//8dux3v-codex/makro-fur-poison-applicator-hinzufugen
-    let effectData;
+  const newQuantity = Math.max((poison.system.quantity ?? 1) - 1, 0);
+  await poison.update({"system.quantity": newQuantity});
 
-    if (game.modules.get('pf2e-extempore-effects')?.active && window.pf2eExtempore?.createEffect) {
-        effectData = await window.pf2eExtempore.createEffect(poison);
+  ChatMessage.create({
+    content: `<b>${actor.name}</b> hat <b>${poison.name}</b> auf <b>${weapon.name}</b> angewendet!`,
+    speaker: ChatMessage.getSpeaker({actor})
+  });
 
-        effectData.name = `Vergiftete Waffe (${poison.name})`;
-        effectData.flags ??= {};
-        effectData.flags.core ??= {};
-        effectData.flags.core.sourceId = poison.uuid;
-
-        effectData.system ??= {};
-        effectData.system.description ??= {};
-        effectData.system.description.value = `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet. @UUID[${poison.uuid}]{${poison.name}}</p>` +
-            effectData.system.description.value;
-        effectData.system.duration = { value: 10, unit: 'rounds' };
-        effectData.system.tokenIcon = { show: true };
-        effectData.system.slug = `poisoned-weapon-${actor.id}-${weapon.id}`;
-    } else {
-        effectData = {
-            name: `Vergiftete Waffe (${poison.name})`,
-            type: "effect",
-            img: poison.img,
-            flags: {
-                core: {
-                    sourceId: poison.uuid
-                }
-//main
-    const effectData = {
-        name: `Vergiftete Waffe (${poison.name})`,
-        type: "effect",
-        img: poison.img,
-        flags: {
-            core: {
-                sourceId: poison.uuid
-            }
-        },
-        system: {
-            description: {
-//wnwig2-codex/makro-fur-poison-applicator-hinzufugen
-                value: `<p>Diese Waffe wurde mit @UUID[${poison.uuid}] vergiftet.</p><hr>${poisonDesc}`,
-                gm: poisonDescGm
-            },
-            duration: { value: 10, unit: "rounds" },
-            tokenIcon: { show: true },
-            rules: [],
-            slug: `poisoned-weapon-${actor.id}-${weapon.id}`
-        }
-    };
-
-//d6xli7-codex/makro-fur-poison-applicator-hinzufugen
-                value: `<p>Diese Waffe wurde mit @UUID[${poison.uuid}] vergiftet.</p><hr>${poisonDesc}`,
-                gm: poisonDescGm
-//lqjd3e-codex/makro-fur-poison-applicator-hinzufugen
-                value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet.</p>` +
-                    `<p>Nutze @UUID[${poison.uuid}] für alle Würfe.</p>`
-                value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet. @UUID[${poison.uuid}]{${poison.name}}</p>` +
-// xrqeqz-codex/makro-fur-poison-applicator-hinzufugen
-                      // `<p>Nutze @UUID[${poison.uuid}] für alle Würfe.</p>`
-                      // `<p>Nutze @UUID[${poison.uuid}]{${poison.name}} für alle Würfe.</p>`
-// main
-          },
-            system: {
-                description: {
-                    value: `<p>Diese Waffe wurde mit <strong>${poison.name}</strong> vergiftet. @UUID[${poison.uuid}]{${poison.name}}</p>` +
-                        `<p>Nutze @UUID[${poison.uuid}] für alle Würfe.</p>`
-                },
-                duration: { value: 10, unit: "rounds" },
-                tokenIcon: { show: true },
-                rules: [],
-                slug: `poisoned-weapon-${actor.id}-${weapon.id}`
-            }
-        };
-    }
-//main
-
-    try {
-        await actor.createEmbeddedDocuments("Item", [effectData]);
-        console.log("🛠️ Effekt erfolgreich auf Token angewendet:", effectData);
-    } catch (error) {
-        console.error("❌ Fehler beim Hinzufügen des Effekts am Token:", error);
-    }
-
-    // 🎯 Die Menge des Gifts im Inventar verringern
-    let newQuantity = (poison.system.quantity ?? 1) - 1;
-    if (newQuantity < 0) newQuantity = 0;
-    await poison.update({ "system.quantity": newQuantity });
-    console.log(`🔢 ${poison.name} wurde reduziert auf ${newQuantity}.`);
-
-    // 💬 Nachricht im Chat posten
-    ChatMessage.create({
-        content: `<b>${actor.name}</b> hat <b>${poison.name}</b> auf <b>${weapon.name}</b> angewendet! Die Waffe ist jetzt vergiftet!`,
-        speaker: ChatMessage.getSpeaker({ actor: actor })
-    });
-
-    ui.notifications.info(`${poison.name} wurde auf ${weapon.name} angewendet.`);
+  ui.notifications.info(`${poison.name} wurde auf ${weapon.name} angewendet.`);
 }


### PR DESCRIPTION
## Summary
- clean up effect creation code
- reference the poison item in the effect description
- clarify usage in README
- bump module version to 1.2.0

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b1eb859048327b08f3b7cf572ece5