### PR TITLE
Send poison effect to chat on hit

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -44,3 +44,29 @@ export async function applyPoisonEffect(actor, weapon, poison) {
 
   ui.notifications.info(`${poison.name} wurde auf ${weapon.name} angewendet.`);
 }
+
+export async function postPoisonEffectOnHit(message) {
+  const context = message.flags?.pf2e?.context;
+  if (!context) return;
+  const outcome = context.outcome;
+  if (!["success", "criticalSuccess"].includes(outcome)) return;
+
+  const actor = message.actor ?? game.actors.get(message.speaker.actor);
+  if (!actor) return;
+
+  const weaponUuid = message.flags?.pf2e?.weaponUuid
+    ?? message.flags?.pf2e?.strike?.item?.uuid
+    ?? message.flags?.pf2e?.origin?.uuid;
+  if (!weaponUuid) return;
+
+  const weapon = await fromUuid(weaponUuid);
+  if (!weapon || weapon.type !== "weapon") return;
+  const effects = Array.from(weapon.system.attackEffects?.value || []);
+  if (!effects.includes("poison")) return;
+
+  const slug = `poisoned-weapon-${actor.id}-${weapon.id}`;
+  const effect = actor.items.find(i => i.type === "effect" && i.system?.slug === slug);
+  if (!effect) return;
+
+  effect.toMessage({}, { create: true });
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,5 @@
 import { registerPoisonApplier } from "./ui.js";
+import { postPoisonEffectOnHit } from "./effects.js";
 
 Hooks.once("ready", async () => {
     console.log("🔹 Poison Applier Modul geladen!");
@@ -32,4 +33,6 @@ Hooks.once("ready", async () => {
     } else {
         console.log("✅ Makro existiert bereits.");
     }
+
+    Hooks.on("createChatMessage", postPoisonEffectOnHit);
 });


### PR DESCRIPTION
## Summary
- Post poison effect item to chat whenever a poisoned weapon scores a successful strike
- Register chat-message hook on module readiness

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16e1520948327b39ab1fbe3e146ba