### PR TITLE
Use token actor for poison effect search

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -51,18 +51,28 @@ export async function postPoisonEffectOnHit(message) {
   const outcome = context.outcome;
   if (!["success", "criticalSuccess", "criticalFailure"].includes(outcome)) return;
 
-  const actor = message.actor ?? game.actors.get(message.speaker.actor);
-  if (!actor) return;
+  const token = canvas.tokens.get(message.speaker.token);
+  const actor = token?.actor ?? message.actor ?? game.actors.get(message.speaker.actor);
+  if (!actor) {
+    console.warn("Poison Applier | Actor not found for message", message);
+    return;
+  }
 
   const weaponUuid = message.flags?.pf2e?.weaponUuid
     ?? message.flags?.pf2e?.strike?.item?.uuid
     ?? message.flags?.pf2e?.origin?.uuid;
-  if (!weaponUuid) return;
+  if (!weaponUuid) {
+    console.warn("Poison Applier | weaponUuid missing on message", message);
+    return;
+  }
 
   const weapon = await fromUuid(weaponUuid);
   if (!weapon || weapon.type !== "weapon") return;
   const effects = Array.from(weapon.system.attackEffects?.value || []);
-  if (!effects.includes("poison")) return;
+  if (!effects.includes("poison")) {
+    console.warn(`Poison Applier | weapon ${weapon.name} lacks poison attack effect.`);
+    return;
+  }
 
   const slug = `poisoned-weapon-${actor.id}-${weapon.id}`;
   const effect = actor.items.find(i => i.type === "effect" && i.system?.slug === slug);


### PR DESCRIPTION
## Summary
- resolve actor from the message token before handling poison effects
- log missing weapon UUID or poison trait for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c189508fbc8327acd7ec2604ceb1ca