### PR TITLE
feat: add jB2A hit animation via Automated Animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,7 @@ Nach dem Aktivieren des Moduls wird beim Spielstart automatisch ein Makro **"Poi
 Nach der Auswahl wird auf dem Token ein Effekt angelegt. Dieser Effekt verlinkt auf das im Spiel hinterlegte Gift und zeigt an, auf welche Waffe es aufgetragen wurde. Aus dem Effekt heraus lassen sich alle Würfe des Giftes (z.B. Schadens- oder Rettungswürfe) verwenden. Gleichzeitig wird die Menge des verwendeten Giftes im Inventar um eins reduziert.
 
 Kompatibel mit Foundry VTT v13.
+
+### Animationen
+
+Damit beim Treffer eine jB2A-Animation abgespielt wird, müssen das Modul [Automated Animations](https://foundryvtt.com/packages/autoanimations) sowie ein passendes jB2A-Asset-Paket installiert und aktiv sein.

--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -76,6 +76,14 @@ export async function postPoisonEffectOnHit(message) {
 
   if (["success", "criticalSuccess"].includes(outcome)) {
     await effect.toMessage({}, { create: true });
+    const aa = game.modules.get("autoanimations")?.API;
+    if (aa) {
+      aa.playAnimation(token, {
+        animation: "jb2a.poison.spray.green",
+        source: token,
+        target: message?.targets?.[0]
+      });
+    }
   }
   await actor.deleteEmbeddedDocuments("Item", [effect.id]);
   await weapon.unsetFlag("pf2e-poison-applier", "poisoned");


### PR DESCRIPTION
## Summary
- add optional Autoanimations hook to play jB2A poison animation on hit
- document Autoanimations and jB2A requirement in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c41a3c07cc83278f069946966fc355