### PR TITLE
Add debug setting for weapon poison logging

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -47,7 +47,8 @@ export async function postPoisonEffectOnHit(message) {
   const context = message.flags?.pf2e?.context;
   if (!context) return;
   const outcome = context.outcome;
-  if (!["success", "criticalSuccess", "criticalFailure"].includes(outcome)) return;
+  const isAttack = ["success", "criticalSuccess", "criticalFailure", "failure"].includes(outcome);
+  if (!isAttack) return;
 
   const token = canvas.tokens.get(message.speaker.token);
   const actor = token?.actor ?? message.actor ?? game.actors.get(message.speaker.actor);
@@ -67,10 +68,15 @@ export async function postPoisonEffectOnHit(message) {
   const weapon = await fromUuid(weaponUuid);
   if (!weapon || weapon.type !== "weapon") return;
   const poisoned = weapon.getFlag(MODULE_ID, "poisoned");
+  if (game.settings.get(MODULE_ID, "debug")) {
+    console.log(`Poison Applier | ${weapon.name} ${poisoned ? "hat ein Gift." : "hat kein Gift."}`);
+  }
   if (!poisoned) {
     console.warn(`Poison Applier | weapon ${weapon.name} lacks poison flag.`);
     return;
   }
+
+  if (!["success", "criticalSuccess", "criticalFailure"].includes(outcome)) return;
 
   const slug = `poisoned-weapon-${actor.id}-${weapon.id}`;
   const effect = actor.items.find(i => i.type === "effect" && i.system?.slug === slug);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,19 @@
 import { registerPoisonApplier } from "./ui.js";
 import { postPoisonEffectOnHit } from "./effects.js";
 
+const MODULE_ID = "poison-applier";
+
+Hooks.once("init", () => {
+    game.settings.register(MODULE_ID, "debug", {
+        name: "Debug-Ausgaben",
+        hint: "Aktiviere zusätzliche Debug-Ausgaben in der Konsole.",
+        scope: "client",
+        config: true,
+        type: Boolean,
+        default: false
+    });
+});
+
 Hooks.once("ready", async () => {
     console.log("🔹 Poison Applier Modul geladen!");
 


### PR DESCRIPTION
## Summary
- add debug setting to toggle console logging
- log whether weapons carry poison after attack roll messages

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52a649dcc83279fd88eace6ea4cb2