### PR TITLE
Log Degree of Success in debug output

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -68,8 +68,12 @@ export async function postPoisonEffectOnHit(message) {
   const weapon = await fromUuid(weaponUuid);
   if (!weapon || weapon.type !== "weapon") return;
   const poisoned = weapon.getFlag(MODULE_ID, "poisoned");
+  const roll = message.rolls?.[0];
+  const dc = context.dc?.value;
+  const dos = roll && dc ? new game.pf2e.DegreeOfSuccess(roll, dc) : null;
   if (game.settings.get(MODULE_ID, "debug")) {
     console.log(`Poison Applier | ${weapon.name} ${poisoned ? "hat ein Gift." : "hat kein Gift."}`);
+    if (dos) console.log(`Poison Applier | DegreeOfSuccess: ${dos.value}`);
   }
   if (!poisoned) {
     console.warn(`Poison Applier | weapon ${weapon.name} lacks poison flag.`);
@@ -79,10 +83,6 @@ export async function postPoisonEffectOnHit(message) {
   const slug = `poisoned-weapon-${actor.id}-${weapon.id}`;
   const effect = actor.items.find(i => i.type === "effect" && i.system?.slug === slug);
   if (!effect) return;
-
-  const roll = message.rolls?.[0];
-  const dc = context.dc?.value;
-  const dos = roll && dc ? new game.pf2e.DegreeOfSuccess(roll, dc) : null;
   if (dos && dos.value >= game.pf2e.DegreeOfSuccess.SUCCESS) {
     await effect.toMessage({}, { create: true });
     const aa = game.modules.get("autoanimations")?.API;


### PR DESCRIPTION
## Summary
- Calculate roll, DC, and degree of success before debug logging in `postPoisonEffectOnHit`
- Expand debug logging to report degree of success

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c542ac0ef483278c132be2db83c39b