### PR TITLE
Fix poison effect slug lookup

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -6,15 +6,16 @@ export async function applyPoisonEffect(actor, weapon, poison) {
   // Mark the weapon as poisoned via a flag
   await weapon.setFlag(MODULE_ID, "poisoned", true);
 
+  const slug = `poisoned-weapon-${actor.id}-${weapon.id}`.toLowerCase();
   const effectData = {
     name: `Vergiftete ${weapon.name} (${poison.name})`,
     type: "effect",
     img: poison.img,
-    slug: `poisoned-weapon-${actor.id}-${weapon.id}`,
     flags: {
       core: { sourceId: poison.uuid }
     },
     system: {
+      slug,
       tokenIcon: { show: true },
       duration: { value: 10, unit: "rounds" },
       rules: [],
@@ -77,7 +78,7 @@ export async function postPoisonEffectOnHit(message) {
     return;
   }
 
-  const slug = `poisoned-weapon-${actor.id}-${weapon.id}`;
+  const slug = `poisoned-weapon-${actor.id}-${weapon.id}`.toLowerCase();
   const effect = actor.items.find(i => i.type === "effect" && i.slug === slug);
   if (!effect) return;
   if (["success", "criticalSuccess"].includes(outcome)) {


### PR DESCRIPTION
## Summary
- ensure poison effect slug uses lower case when created and searched
- store effect slug inside system data so lookup succeeds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c566d2fbac8327b557129dd761837c