### PR TITLE
Translate module interface text to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # PF2e-Foundry-VTT-Poison-Applier
 
-Dieses Modul erleichtert es, den Einsatz von Giften in Foundry VTT zu verfolgen. Nach dem Auftragen wird deutlich angezeigt, welche Waffe mit welchem Gift behandelt wurde.
+This module makes it easier to track the use of poisons in Foundry VTT. After application, it clearly shows which weapon has been treated with which poison.
 
-## Nutzung
+## Usage
 
-Nach dem Aktivieren des Moduls wird beim Spielstart automatisch ein Makro **"Poison Applicator"** erstellt. Führe dieses Makro aus, um einen Dialog zu öffnen. Dort wählst du eine Waffe und ein passendes Gift aus dem Inventar des gewählten Tokens.
+After enabling the module, a macro **"Poison Applicator"** is automatically created at game start. Run this macro to open a dialog where you select a weapon and a suitable poison from the selected token's inventory.
 
-Nach der Auswahl wird auf dem Token ein Effekt angelegt. Dieser Effekt verlinkt auf das im Spiel hinterlegte Gift und zeigt an, auf welche Waffe es aufgetragen wurde. Aus dem Effekt heraus lassen sich alle Würfe des Giftes (z.B. Schadens- oder Rettungswürfe) verwenden. Gleichzeitig wird die Menge des verwendeten Giftes im Inventar um eins reduziert.
+After selection, an effect is added to the token. This effect links to the in-game poison and displays the weapon it was applied to. From the effect you can perform any rolls the poison requires (e.g. damage or saving throws). At the same time, the quantity of the poison in the inventory is reduced by one.
 
-Kompatibel mit Foundry VTT v13.
+Compatible with Foundry VTT v13.
 
-### Animationen
+### Animations
 
-Damit beim Treffer eine jB2A-Animation abgespielt wird, müssen das Modul [Automated Animations](https://foundryvtt.com/packages/autoanimations) sowie ein passendes jB2A-Asset-Paket installiert und aktiv sein.
+To play a jB2A animation on a hit, the [Automated Animations](https://foundryvtt.com/packages/autoanimations) module and a suitable jB2A asset pack must be installed and active.

--- a/module.json
+++ b/module.json
@@ -1,7 +1,7 @@
 {
   "id": "poison-applier",
   "title": "PF2e Poison-Applier",
-  "description": "Ermöglicht das Auftragen von Giften auf Waffen mit visuellen Effekten.",
+  "description": "Allows applying poisons to weapons with visual effects.",
   "version": "1.2.0",
   "type": "module",
   "compatibility": {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5,8 +5,8 @@ const MODULE_ID = "poison-applier";
 
 Hooks.once("init", () => {
     game.settings.register(MODULE_ID, "debug", {
-        name: "Debug-Ausgaben",
-        hint: "Aktiviere zusätzliche Debug-Ausgaben in der Konsole.",
+        name: "Debug output",
+        hint: "Enable additional debug output in the console.",
         scope: "client",
         config: true,
         type: Boolean,
@@ -15,36 +15,36 @@ Hooks.once("init", () => {
 });
 
 Hooks.once("ready", async () => {
-    console.log("🔹 Poison Applier Modul geladen!");
+    console.log("🔹 Poison Applier module loaded!");
 
-    // Registriere die API für das Modul
+    // Register the API for the module
     registerPoisonApplier();
 
-    // Makro erstellen (Falls nicht vorhanden)
+    // Create macro (if not already present)
     let macro = game.macros.find(m => m.name === "Poison Applicator");
     if (!macro) {
-        console.log("🛠️ Erstelle neues Makro für Poison Applicator...");
+        console.log("🛠️ Creating new macro for Poison Applicator...");
         macro = await Macro.create({
             name: "Poison Applicator",
             type: "script",
             scope: "global",
             command: `
                 if (!canvas.tokens.controlled.length) {
-                    ui.notifications.warn("Bitte ein Token auswählen!");
+                    ui.notifications.warn("Please select a token!");
                     return;
                 }
                 let selectedActor = canvas.tokens.controlled[0]?.actor;
                 if (!selectedActor) {
-                    ui.notifications.error("Kein gültiger Actor gefunden!");
+                    ui.notifications.error("No valid actor found!");
                     return;
                 }
                 game.modules.get("poison-applier").api.showPoisonDialog(selectedActor);
             `,
             img: "icons/skills/toxins/poison-bottle-green.webp"
         });
-        console.log("✅ Makro erfolgreich erstellt:", macro);
+        console.log("✅ Macro successfully created:", macro);
     } else {
-        console.log("✅ Makro existiert bereits.");
+        console.log("✅ Macro already exists.");
     }
 
     Hooks.on("createChatMessage", postPoisonEffectOnHit);

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -16,13 +16,13 @@ async function applyPoison(actor, weaponId, poisonId) {
     let poison = actor.items.get(poisonId);
 
     if (!weapon || !poison) {
-        ui.notifications.error("Fehler beim Anwenden des Gifts.");
+        ui.notifications.error("Error applying poison.");
         return;
     }
 
-    // Sicherstellen, dass nur echte Waffen vergiftet werden können
+    // Ensure only actual weapons can be poisoned
     if (weapon.type !== "weapon") {
-        ui.notifications.error("Du kannst nur Waffen vergiften!");
+        ui.notifications.error("You can only poison weapons!");
         return;
     }
 
@@ -33,23 +33,23 @@ async function applyPoison(actor, weaponId, poisonId) {
 // 🛠 Dialog zur Auswahl der Waffe und des Gifts
 async function showPoisonDialog(actor) {
     if (!actor) {
-        ui.notifications.error("Kein gültiger Schauspieler (Actor) ausgewählt.");
+        ui.notifications.error("No valid actor selected.");
         return;
     }
 
-    console.log(`📌 Gewählter Actor: ${actor.name}`, actor);
+    console.log(`📌 Selected actor: ${actor.name}`, actor);
 
     let weapons = getWeapons(actor);
     let poisons = getPoisons(actor);
 
 
     if (weapons.length === 0) {
-        ui.notifications.warn("Du hast keine Waffen, die vergiftet werden können.");
+        ui.notifications.warn("You have no weapons that can be poisoned.");
         return;
     }
 
     if (poisons.length === 0) {
-        ui.notifications.warn("Du hast keine Gifte im Inventar.");
+        ui.notifications.warn("You have no poisons in your inventory.");
         return;
     }
 
@@ -57,11 +57,11 @@ async function showPoisonDialog(actor) {
     const content = await renderTemplate(templatePath, { weapons, poisons });
 
     new Dialog({
-        title: "Gift auf Waffe auftragen",
+        title: "Apply poison to weapon",
         content,
         buttons: {
             apply: {
-                label: "Anwenden",
+                label: "Apply",
                 callback: (html) => {
                     let weaponId = html.find("#weapon").val();
                     let poisonId = html.find("#poison").val();
@@ -69,7 +69,7 @@ async function showPoisonDialog(actor) {
                 }
             },
             cancel: {
-                label: "Abbrechen"
+                label: "Cancel"
             }
         }
     }).render(true);


### PR DESCRIPTION
## Summary
- Translate debug setting and macro-related messages to English
- Localize UI notifications and dialog labels
- Update module description and README to English

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c56e0318d4832784708863c783fc38