### PR TITLE
Translate poison dialog labels to English

### DIFF
--- a/templates/apply-poison.html
+++ b/templates/apply-poison.html
@@ -1,6 +1,6 @@
 <form>
     <div class="form-group">
-        <label>Waffe:</label>
+        <label>Weapon:</label>
         <select id="weapon">
             {{#each weapons}}
             <option value="{{this.id}}">{{this.name}}</option>
@@ -8,7 +8,7 @@
         </select>
     </div>
     <div class="form-group">
-        <label>Gift:</label>
+        <label>Poison:</label>
         <select id="poison">
             {{#each poisons}}
             <option value="{{this.id}}">{{this.name}}</option>


### PR DESCRIPTION
## Summary
- replace "Waffe" and "Gift" labels with English equivalents in apply-poison dialog

## Testing
- `NODE_PATH=/tmp/poison/node_modules node -e "const fs=require('fs'); const Handlebars=require('handlebars'); const tpl=Handlebars.compile(fs.readFileSync('templates/apply-poison.html','utf8')); const html=tpl({weapons:[{id:'w1',name:'Sword'}],poisons:[{id:'p1',name:'Nightshade'}]}); console.log(html);"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5704aff008327b2ad41b5769c1ce2