### PR TITLE
Update macro icon path

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -40,7 +40,7 @@ Hooks.once("ready", async () => {
                 }
                 game.modules.get("poison-applier").api.showPoisonDialog(selectedActor);
             `,
-            img: "icons/skills/toxins/poison-bottle-green.webp"
+            img: "systems/pf2e/icons/equipment/alchemical-items/alchemical-poisons.webp"
         });
         console.log("✅ Macro successfully created:", macro);
     } else {


### PR DESCRIPTION
## Summary
- Use PF2E alchemical poisons icon for Poison Applicator macro

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5753d60208327bf11c77bf182f785