### PR TITLE
Use Sequencer for poison splash animation

### DIFF
--- a/scripts/effects.js
+++ b/scripts/effects.js
@@ -83,13 +83,16 @@ export async function postPoisonEffectOnHit(message) {
   if (!effect) return;
   if (["success", "criticalSuccess"].includes(outcome)) {
     await effect.toMessage({}, { create: true });
-    const aa = game.modules.get("autoanimations")?.API;
-    if (aa) {
-      aa.playAnimation(token, {
-        animation: "jb2a.poison.spray.green",
-        source: token,
-        target: message?.targets?.[0]
-      });
+    const target = message?.targets?.[0];
+    if (game.modules.get("autoanimations")?.active && game.modules.get("sequencer")?.active && target) {
+      if (game.settings.get(MODULE_ID, "debug")) {
+        console.log("Poison Applier | Playing poison effect animation via Sequencer.");
+      }
+      new Sequence()
+        .effect()
+          .file("autoanimations.static.liquid.splash.01.green")
+          .atLocation(target)
+        .play();
     }
   }
   await actor.deleteEmbeddedDocuments("Item", [effect.id]);


### PR DESCRIPTION
## Summary
- switch poison hit animation to Sequencer with autoanimations integration
- add debug logging for animation trigger

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c57ca3e4dc8327afd759283292f2da