### PR TITLE
Add Poison Coat support to poison application dialog

### DIFF
--- a/templates/apply-poison.html
+++ b/templates/apply-poison.html
@@ -15,4 +15,10 @@
             {{/each}}
         </select>
     </div>
+    {{#if hasPoisonCoat}}
+    <div class="form-group">
+        <label for="poison-coat">Activate Poison Coat feat (skip weapon validation)</label>
+        <input type="checkbox" id="poison-coat" />
+    </div>
+    {{/if}}
 </form>


### PR DESCRIPTION
## Summary
- detect actors with the Poison Coat feat and expose a toggle in the poison application dialog
- plumb the Poison Coat selection through the dialog callback so applyPoison can skip weapon validation
- create a dedicated Poison Coat effect application that consumes the poison and adds an effect item to the actor

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ce7f6dbacc8327abc0b59b6bc88695